### PR TITLE
fix: validate provider in resolve_config (#11)

### DIFF
--- a/optmix/core/config.py
+++ b/optmix/core/config.py
@@ -123,11 +123,26 @@ def resolve_config(
 
     Returns:
         Fully resolved OptMixConfig.
+
+    Raises:
+        ValueError: If provider is not in SUPPORTED_PROVIDERS.
     """
+    # Validate provider if provided
+    if provider is not None and provider not in SUPPORTED_PROVIDERS:
+        raise ValueError(
+            f"Unsupported provider: '{provider}'. Supported providers: {SUPPORTED_PROVIDERS}"
+        )
+
     file_cfg = load_config(config_path)
 
     # Provider: CLI flag > config file > default
     resolved_provider = provider or file_cfg.provider or "anthropic"
+
+    # Validate resolved provider from config file
+    if resolved_provider not in SUPPORTED_PROVIDERS:
+        raise ValueError(
+            f"Unsupported provider in config: '{resolved_provider}'. Supported providers: {SUPPORTED_PROVIDERS}"
+        )
 
     # Model: CLI flag > config file > default for provider
     resolved_model = model or file_cfg.model or DEFAULT_MODELS.get(resolved_provider, "")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -164,3 +164,19 @@ class TestResolveConfig:
         monkeypatch.setenv("OPTMIX_API_KEY", "sk-optmix-shared")
         cfg = resolve_config(config_path=tmp_path / "nope.yaml")
         assert cfg.api_key == "sk-optmix-shared"
+
+    def test_invalid_cli_provider_raises_value_error(self, tmp_path):
+        with pytest.raises(ValueError) as exc_info:
+            resolve_config(provider="invalid_provider", config_path=tmp_path / "nope.yaml")
+        assert "Unsupported provider" in str(exc_info.value)
+        assert "invalid_provider" in str(exc_info.value)
+        assert "anthropic" in str(exc_info.value)
+        assert "openai" in str(exc_info.value)
+
+    def test_invalid_config_provider_raises_value_error(self, tmp_config):
+        # Save config with invalid provider
+        tmp_config.write_text(yaml.dump({"provider": "invalid_provider"}))
+        with pytest.raises(ValueError) as exc_info:
+            resolve_config(config_path=tmp_config)
+        assert "Unsupported provider in config" in str(exc_info.value)
+        assert "invalid_provider" in str(exc_info.value)


### PR DESCRIPTION
## Summary
Added provider validation to `resolve_config()` to prevent silent creation of invalid configs when an unknown provider is specified.

## Changes
- Added validation against `SUPPORTED_PROVIDERS` for CLI-provided provider
- Added validation against `SUPPORTED_PROVIDERS` for config file provider
- Raises `ValueError` with clear error message listing supported providers
- Added test cases for both validation paths

## Type
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Tests

## Testing
- [x] Added/updated tests
- [ ] All tests pass (`python -m pytest tests/ -m "not slow"`)