### PR TITLE
Add provider validation in resolve_config

### DIFF
--- a/optmix/core/config.py
+++ b/optmix/core/config.py
@@ -123,11 +123,26 @@ def resolve_config(
 
     Returns:
         Fully resolved OptMixConfig.
+
+    Raises:
+        ValueError: If provider is not in SUPPORTED_PROVIDERS.
     """
+    # Validate provider if provided
+    if provider is not None and provider not in SUPPORTED_PROVIDERS:
+        raise ValueError(
+            f"Unsupported provider: '{provider}'. Supported providers: {SUPPORTED_PROVIDERS}"
+        )
+
     file_cfg = load_config(config_path)
 
     # Provider: CLI flag > config file > default
     resolved_provider = provider or file_cfg.provider or "anthropic"
+
+    # Validate resolved provider from config file
+    if resolved_provider not in SUPPORTED_PROVIDERS:
+        raise ValueError(
+            f"Unsupported provider in config: '{resolved_provider}'. Supported providers: {SUPPORTED_PROVIDERS}"
+        )
 
     # Model: CLI flag > config file > default for provider
     resolved_model = model or file_cfg.model or DEFAULT_MODELS.get(resolved_provider, "")


### PR DESCRIPTION
Fixes issue #11: now raises a ValueError instead of silently creating an invalid config.

## Summary
This PR adds validation for the  parameter in the  function to ensure it is a valid provider from the  list.

## Changes
- Validate CLI-provided provider against SUPPORTED_PROVIDERS list
- Validate provider loaded from config file against SUPPORTED_PROVIDERS list
- Raises ValueError with helpful message listing supported providers

## Type
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests

## Testing
- [x] Added/updated tests
- [ ] All tests pass

## Related Issues
Fixes #11