### PR TITLE
fix: align README and agent YAMLs with actual Python tool names

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You: "Our CAC increased 23% last quarter. What's driving it and how do we fix it
 
 Strategist Maya: "Let me pull the context. Loading your channel data..."
 Analyst Kai:     "Running decomposition. TV adstock is carrying over into wasted frequency..."
-Modeler Alex:    "Bayesian MMM fitted. Saturation curves show Meta is past inflection point..."
+Modeler Priya:   "Bayesian MMM fitted. Saturation curves show Meta is past inflection point..."
 Optimizer Ravi:  "Reallocation ready. Shifting 18% from Meta to TikTok yields +12% ROAS..."
 Reporter Nora:   "Executive summary generated with confidence intervals and scenario comparison."
 ```
@@ -96,15 +96,15 @@ Inside `optmix chat`:
 
 ## The Agents
 
-Each agent is a fully defined persona with specialized tools, defined as YAML configuration files. Agents can **delegate tasks to each other** automatically — ask Maya a modeling question and she'll consult Alex.
+Each agent is a fully defined persona with specialized tools, defined as YAML configuration files. Agents can **delegate tasks to each other** automatically — ask Maya a modeling question and she'll consult Priya.
 
 | Agent | Persona | Role | Core Tools |
 |-------|---------|------|------------|
-| **Strategist** | Maya Chen | Sets business context, defines KPIs, creates measurement briefs | `market_context_builder`, `kpi_framework`, `channel_portfolio_analyzer` |
-| **Analyst** | Kai Nakamura | Data validation, EDA, feature engineering, anomaly detection | `data_validator`, `eda_profiler`, `feature_engineer` |
-| **Modeler** | Alex Petrov | Builds & fits MMM models, runs diagnostics, extracts contributions | `fit_mmm_model`, `model_diagnostics`, `contribution_decomposer` |
-| **Optimizer** | Ravi Santos | Budget allocation, scenario simulation, constrained optimization | `budget_optimizer`, `scenario_simulator`, `marginal_roi_calculator` |
-| **Reporter** | Nora Lindqvist | Generates executive reports, visualizations, and action plans | `report_generator`, `chart_builder`, `action_plan_creator` |
+| **Strategist** | Maya Chen | Sets business context, defines KPIs, creates measurement briefs | `load_industry_benchmarks`, `load_channel_taxonomy`, `assess_data_readiness` |
+| **Analyst** | Kai Nakamura | Data validation, EDA, feature engineering, anomaly detection | `validate_data`, `run_eda`, `describe_channels` |
+| **Modeler** | Priya Sharma | Builds & fits MMM models, runs diagnostics, extracts contributions | `fit_mmm_model`, `get_model_diagnostics`, `get_channel_contributions` |
+| **Optimizer** | Ravi Santos | Budget allocation, scenario simulation, constrained optimization | `optimize_budget`, `run_scenario`, `get_marginal_roas` |
+| **Reporter** | Nora Lindqvist | Generates executive reports, visualizations, and action plans | `generate_markdown_report`, `generate_chart`, `create_action_plan` |
 | **Orchestrator** | — | Routes tasks, manages shared state, ensures context handoffs | Automatic routing based on query content |
 
 ### Agent Interaction Example
@@ -211,24 +211,54 @@ print(scenario.expected_lift_pct)  # Revenue change %
 Workflows are YAML files that define structured, multi-step processes with quality gates between phases.
 
 ```yaml
-# workflows/full_measurement_cycle.yaml
+# workflows/full_measurement_cycle.yaml (simplified)
 workflow:
   name: full-measurement-cycle
   title: "End-to-End Marketing Measurement"
-  steps:
-    - agent: strategist
-      action: build-market-context
-    - agent: analyst
-      action: validate-data
-    - agent: analyst
-      action: run-eda
-    - agent: modeler
-      action: fit-model
-      gate: model-validation-checklist
-    - agent: optimizer
-      action: optimize-budget
-    - agent: reporter
-      action: generate-report
+  phases:
+    - name: strategize
+      steps:
+        - id: market_context
+          agent: strategist
+          action: market-context
+        - id: data_readiness
+          agent: strategist
+          action: data-readiness
+          gate: data-readiness-checklist
+
+    - name: model
+      steps:
+        - id: validate_data
+          agent: analyst
+          action: validate
+        - id: run_eda
+          agent: analyst
+          action: eda
+        - id: fit_model
+          agent: modeler
+          action: fit
+        - id: run_diagnostics
+          agent: modeler
+          action: diagnostics
+          gate: model-validation-checklist
+
+    - name: optimize
+      steps:
+        - id: optimize_budget
+          agent: optimizer
+          action: optimize
+        - id: calculate_mroas
+          agent: optimizer
+          action: marginal-roas
+
+    - name: activate
+      steps:
+        - id: executive_report
+          agent: reporter
+          action: report
+        - id: action_plan
+          agent: reporter
+          action: action-plan
 ```
 
 Run with:

--- a/agents/analyst.agent.yaml
+++ b/agents/analyst.agent.yaml
@@ -34,13 +34,11 @@ agent:
       - "If a number looks too good to be true, it's probably a data error"
 
   tools:
-    - data_validator
-    - eda_profiler
-    - feature_engineer
-    - anomaly_detector
-    - collinearity_checker
-    - seasonality_decomposer
-    - data_transformer
+    - load_csv_data
+    - load_sample_data
+    - validate_data
+    - run_eda
+    - describe_channels
 
   menu:
     - trigger: "validate"

--- a/agents/modeler.agent.yaml
+++ b/agents/modeler.agent.yaml
@@ -35,16 +35,13 @@ agent:
       - "The model card is as important as the model itself"
 
   tools:
-    - bayesian_mmm_fitter
-    - lightweight_mmm_fitter
-    - ridge_mmm_fitter
-    - adstock_configurator
-    - saturation_configurator
-    - model_diagnostics_runner
-    - contribution_decomposer
-    - saturation_curve_analyzer
-    - prior_elicitor
-    - model_comparator
+    - fit_mmm_model
+    - get_channel_contributions
+    - get_saturation_curves
+    - get_model_diagnostics
+    - load_sample_data
+    - load_industry_benchmarks
+    - get_marginal_roas
 
   menu:
     - trigger: "fit"

--- a/agents/optimizer.agent.yaml
+++ b/agents/optimizer.agent.yaml
@@ -35,13 +35,10 @@ agent:
       - "Present recommendations in dollar amounts — executives don't think in parameters"
 
   tools:
-    - budget_optimizer
-    - scenario_simulator
-    - constraint_solver
-    - marginal_roas_calculator
-    - sensitivity_analyzer
-    - allocation_comparator
-    - diminishing_returns_quantifier
+    - optimize_budget
+    - run_scenario
+    - get_marginal_roas
+    - get_saturation_curves
 
   menu:
     - trigger: "optimize"

--- a/agents/reporter.agent.yaml
+++ b/agents/reporter.agent.yaml
@@ -33,12 +33,10 @@ agent:
       - "Compare to benchmarks — absolute numbers mean nothing without context"
 
   tools:
-    - report_generator
-    - chart_builder
-    - insight_narrator
-    - action_plan_creator
-    - presentation_builder
-    - benchmark_comparator
+    - generate_markdown_report
+    - generate_chart
+    - create_action_plan
+    - get_channel_contributions
 
   menu:
     - trigger: "report"

--- a/agents/strategist.agent.yaml
+++ b/agents/strategist.agent.yaml
@@ -34,11 +34,12 @@ agent:
       - "Budget constraints are features, not bugs — they force strategic prioritization"
 
   tools:
-    - market_context_builder
-    - kpi_framework_generator
-    - channel_portfolio_analyzer
-    - competitive_benchmark_loader
-    - data_readiness_assessor
+    - load_industry_benchmarks
+    - load_channel_taxonomy
+    - assess_data_readiness
+    - load_csv_data
+    - load_sample_data
+    - describe_channels
 
   menu:
     - trigger: "market-context"


### PR DESCRIPTION
## Summary
- Updated all 5 agent YAML files to use the real tool names from Python (`*_tools.py`) instead of aspirational/design names that didn't match the code
- Fixed modeler persona from "Alex Petrov" to "Priya Sharma" (matching `modeler.agent.yaml` and Python docstrings)
- Updated README agent table with correct tool names and persona
- Replaced simplified workflow YAML example with the real phase-based structure from `full_measurement_cycle.yaml`

## Test plan
- [x] `optmix team` displays correct tool names for all agents
- [x] `python -c "from optmix.core.team import OptMixTeam"` imports without error
- [x] `grep -r "Alex Petrov"` returns zero matches
- [x] All YAML tool names match registered Python tool names in `agent_scope`
- [ ] `optmix chat --sample ecommerce` runs end-to-end
- [ ] `pytest tests/ -m "not slow"` passes